### PR TITLE
Fix duplicate dead cap field

### DIFF
--- a/backend/app/app.py
+++ b/backend/app/app.py
@@ -64,7 +64,7 @@ def get_players():
             "salary": item["2025"],
             "deadCap2026": item[2026],
             "deadCap2027": item[2027],
-            "deadCap2027": item[2028],
+            "deadCap2028": item[2028],
         })
 
     return jsonify(pythonize(players))


### PR DESCRIPTION
## Summary
- fix `deadCap2028` key in player response

## Testing
- `pre-commit` *(fails: no hook config)*

------
https://chatgpt.com/codex/tasks/task_e_6841d6b52db88331ac73f1ec11a905ae