### PR TITLE
Fix login fetch and profile URL

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -19,7 +19,14 @@ const LoginPage = () => {
     e.preventDefault();
     setError("");
     try {
-      await login(username, password);
+      const res = await fetch(`${API_URL}/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password })
+      });
+      if (!res.ok) throw new Error("Login failed");
+      const data = await res.json();
+      login(data.user.username, data.user.teams);
       navigate("/profile");
     } catch {
       setError("Login inválido. Confira usuário e senha.");

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -23,7 +23,7 @@ const ProfilePage = () => {
     setLoading(true);
     try {
       const [capRes, playerRes] = await Promise.all([
-        fetch(`${API_URL}profile/cap-summary/${teamName}`),
+        fetch(`${API_URL}/profile/cap-summary/${teamName}`),
         fetch(`${API_URL}/profile/players/${teamName}`)
       ]);
       const capJson = await capRes.json();


### PR DESCRIPTION
## Summary
- call the backend login API before setting auth context
- fix profile page fetch path

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841d87617288331992a70d9c7bfd3f8