### PR TITLE
Fix API URL handling for fly deployments

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,1 @@
-VITE_API_URL=https://be-capernam.fly.dev/
+VITE_API_URL=https://be-capernam.fly.dev

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -3,10 +3,13 @@ import { Link } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import {
-  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@/components/ui/select";
-
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+import { API_URL } from "@/utils/apiUtils";
 
 const Dashboard = () => {
   const [teamsData, setTeamsData] = useState<any[]>([]);

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -5,8 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
-
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+import { API_URL } from "@/utils/apiUtils";
 
 const LoginPage = () => {
   const { login } = useAuth();

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -3,8 +3,6 @@ import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Link } from "react-router-dom";
 
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
-
 const NotFound = () => {
   const location = useLocation();
 

--- a/frontend/src/pages/PlayersPage.tsx
+++ b/frontend/src/pages/PlayersPage.tsx
@@ -45,7 +45,7 @@ const columns = [
   { key: "salary", label: "Salary" },
 ];
 
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+import { API_URL } from "@/utils/apiUtils";
 
 const formatMoney = (val: number) =>
   isNaN(val) || val === 0 ? "-" : `$${(val / 1_000_000).toFixed(1)}M`;

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -3,10 +3,10 @@ import { useAuth } from "@/contexts/AuthContext";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { API_URL } from "@/utils/apiUtils";
 // import { teamLogos } from "@/constants/teamLogos";
 // import GenericLogo from "@/assets/logos/genericlogo.jpeg"; // Uma logo padrão
 
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
 const ProfilePage = () => {
   const { user } = useAuth();

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -4,8 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
-
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+import { API_URL } from "@/utils/apiUtils";
 
 const RegisterPage = () => {
   const navigate = useNavigate();

--- a/frontend/src/pages/SchedulePage.tsx
+++ b/frontend/src/pages/SchedulePage.tsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import {
-  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@/components/ui/select";
-
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+import { API_URL } from "@/utils/apiUtils";
 
 const SchedulePage = () => {
   const [scheduleData, setScheduleData] = useState<{ AFC: any[]; NFC: any[] }>({ AFC: [], NFC: [] });

--- a/frontend/src/pages/StatsAll.tsx
+++ b/frontend/src/pages/StatsAll.tsx
@@ -22,8 +22,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { positions, teams } from "@/constants/constants";
-
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+import { API_URL } from "@/utils/apiUtils";
 
 const StatsAll = () => {
   const [allStats, setAllStats] = useState<any[]>([]);

--- a/frontend/src/pages/StatsPage.All.tsx
+++ b/frontend/src/pages/StatsPage.All.tsx
@@ -9,10 +9,12 @@ import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
 import {
-  Card, CardHeader, CardTitle, CardContent,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
 } from "@/components/ui/card";
-
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+import { API_URL } from "@/utils/apiUtils";
 
 const StatsAll = () => {
   const [allStats, setAllStats] = useState([]);
@@ -25,7 +27,7 @@ const StatsAll = () => {
   useEffect(() => {
     const fetchStats = async () => {
       try {
-        const response = await axios.get("http://127.0.0.1:5000/stats");
+        const response = await axios.get(`${API_URL}/stats`);
         const data = response.data;
         const players = data.ALL || [];
         setAllStats(players);

--- a/frontend/src/pages/StatsPage.DB.tsx
+++ b/frontend/src/pages/StatsPage.DB.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios'; // Use axios for API calls
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+import { API_URL } from "@/utils/apiUtils";
 
 const DBStats = () => {
   const [dbStats, setDbStats] = useState([]);
@@ -13,7 +12,7 @@ const DBStats = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await axios.get(`http://127.0.0.1:5000/api/import_weekly_data/${year}`); // Updated API endpoint
+        const response = await axios.get(`${API_URL}/api/import_weekly_data/${year}`);
         console.log('Fetched DB Stats:', response.data); // Log the fetched data
         setDbStats(response.data); // Adjust this line based on the actual data structure returned
       } catch (err) {

--- a/frontend/src/pages/StatsPage.DL.tsx
+++ b/frontend/src/pages/StatsPage.DL.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios'; // Use axios for API calls
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+import { API_URL } from "@/utils/apiUtils";
 
 const DLStats = () => {
   const [dlStats, setDlStats] = useState([]);
@@ -12,7 +12,7 @@ const DLStats = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await axios.get(`http://127.0.0.1:5000/api/import_weekly_data/${year}`); // Updated API endpoint
+        const response = await axios.get(`${API_URL}/api/import_weekly_data/${year}`);
         console.log('Fetched DL Stats:', response.data); // Log the fetched data
         setDlStats(response.data); // Adjust this line based on the actual data structure returned
       } catch (err) {

--- a/frontend/src/pages/StatsPage.IDP.tsx
+++ b/frontend/src/pages/StatsPage.IDP.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios'; // Use axios for API calls
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+import { API_URL } from "@/utils/apiUtils";
 const IDPStats = () => {
   const [idpStats, setIdpStats] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -12,7 +11,7 @@ const IDPStats = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await axios.get(`http://127.0.0.1:5000/api/import_weekly_data/${year}`); // Updated API endpoint
+        const response = await axios.get(`${API_URL}/api/import_weekly_data/${year}`);
         console.log('Fetched IDP Stats:', response.data); // Log the fetched data
         setIdpStats(response.data); // Adjust this line based on the actual data structure returned
       } catch (err) {

--- a/frontend/src/pages/StatsPage.LB.tsx
+++ b/frontend/src/pages/StatsPage.LB.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios'; // Use axios for API calls
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+import { API_URL } from "@/utils/apiUtils";
 const LBStats = () => {
   const [lbStats, setLbStats] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -12,7 +11,7 @@ const LBStats = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await axios.get(`http://127.0.0.1:5000/api/import_weekly_data/${year}`); // Updated API endpoint
+        const response = await axios.get(`${API_URL}/api/import_weekly_data/${year}`);
         console.log('Fetched LB Stats:', response.data); // Log the fetched data
         setLbStats(response.data); // Adjust this line based on the actual data structure returned
       } catch (err) {

--- a/frontend/src/pages/StatsPage.QB.tsx
+++ b/frontend/src/pages/StatsPage.QB.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios'; // Use axios for API calls
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+import { API_URL } from "@/utils/apiUtils";
 const QBStats = () => {
   const [qbStats, setQbStats] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -12,7 +11,7 @@ const QBStats = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await axios.get(`http://127.0.0.1:5000/api/import_weekly_data/${year}`); // Updated API endpoint
+        const response = await axios.get(`${API_URL}/api/import_weekly_data/${year}`);
         console.log('Fetched QB Stats:', response.data); // Log the fetched data
         setQbStats(response.data); // Adjust this line based on the actual data structure returned
       } catch (err) {

--- a/frontend/src/pages/StatsPage.RB.tsx
+++ b/frontend/src/pages/StatsPage.RB.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios'; // Use axios for API calls
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+import { API_URL } from "@/utils/apiUtils";
 const RBStats = () => {
   const [rbStats, setRbStats] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -12,7 +11,7 @@ const RBStats = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await axios.get(`http://127.0.0.1:5000/api/import_weekly_data/${year}`); // Updated API endpoint
+        const response = await axios.get(`${API_URL}/api/import_weekly_data/${year}`);
         console.log('Fetched RB Stats:', response.data); // Log the fetched data
         setRbStats(response.data); // Adjust this line based on the actual data structure returned
       } catch (err) {

--- a/frontend/src/pages/StatsPage.TE.tsx
+++ b/frontend/src/pages/StatsPage.TE.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios'; // Use axios for API calls
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+import { API_URL } from "@/utils/apiUtils";
 const TEStats = () => {
   const [teStats, setTeStats] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -12,7 +11,7 @@ const TEStats = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await axios.get(`http://127.0.0.1:5000/api/import_weekly_data/${year}`); // Updated API endpoint
+        const response = await axios.get(`${API_URL}/api/import_weekly_data/${year}`);
         console.log('Fetched TE Stats:', response.data); // Log the fetched data
         setTeStats(response.data); // Adjust this line based on the actual data structure returned
       } catch (err) {

--- a/frontend/src/pages/StatsPage.WR.tsx
+++ b/frontend/src/pages/StatsPage.WR.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios'; // Use axios for API calls
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+import { API_URL } from "@/utils/apiUtils";
 const WRStats = () => {
   const [wrStats, setWrStats] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -12,7 +11,7 @@ const WRStats = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await axios.get(`http://127.0.0.1:5000/api/import_weekly_data/${year}`); // Updated API endpoint
+        const response = await axios.get(`${API_URL}/api/import_weekly_data/${year}`);
         console.log('Fetched WR Stats:', response.data); // Log the fetched data
         setWrStats(response.data); // Adjust this line based on the actual data structure returned
       } catch (err) {

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -33,8 +33,7 @@ import {
   statsFieldsByPosition,
   seasons,
 } from "@/constants/constants";
-
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+import { API_URL } from "@/utils/apiUtils";
 const StatsPage = () => {
   const [season, setSeason] = useState("2025");
   const [statsData, setStatsData] = useState<Record<string, any[]>>({});

--- a/frontend/src/pages/TeamDetailPage.tsx
+++ b/frontend/src/pages/TeamDetailPage.tsx
@@ -17,7 +17,7 @@ import {
 } from "chart.js";
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
 
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+import { API_URL } from "@/utils/apiUtils";
 
 
 // Função para importar logo pelo teamId

--- a/frontend/src/pages/TeamsPage.tsx
+++ b/frontend/src/pages/TeamsPage.tsx
@@ -5,10 +5,13 @@ import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow
 } from "@/components/ui/table";
 import {
-  Select, SelectContent, SelectItem, SelectTrigger, SelectValue
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@/components/ui/select";
-
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+import { API_URL } from "@/utils/apiUtils";
 type Team = {
   id: string;
   name: string;

--- a/frontend/src/utils/apiUtils.ts
+++ b/frontend/src/utils/apiUtils.ts
@@ -1,6 +1,12 @@
 
 import { toast } from "sonner";
 
+// Base URL for the backend API. Removes any trailing slash to avoid
+// double slashes when concatenating paths.
+export const API_URL = (
+  import.meta.env.VITE_API_URL || "http://localhost:5000"
+).replace(/\/+$/, "");
+
 /**
  * Generic function to fetch data from an API
  */


### PR DESCRIPTION
## Summary
- normalize backend API base URL
- fix players and stats pages to use shared API_URL constant
- adjust environment config to use fly URL without trailing slash

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6879881b3d088331bfd832622dc390c1