### PR TITLE
Fix TeamDetailPage data loading

### DIFF
--- a/frontend/src/pages/TeamDetailPage.tsx
+++ b/frontend/src/pages/TeamDetailPage.tsx
@@ -17,7 +17,7 @@ import {
 } from "chart.js";
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
 
-import { API_URL } from "@/utils/apiUtils";
+import { fetchFromApi } from "@/utils/apiUtils";
 
 
 // Função para importar logo pelo teamId
@@ -40,12 +40,16 @@ const TeamDetailPage = () => {
     const fetchTeamData = async () => {
       setLoading(true);
       try {
-        const [teamsRes, playersRes] = await Promise.all([
-          fetch(`${API_URL}/teams`),
-          fetch(`${API_URL}/players`)
+        const [teams, players] = await Promise.all([
+          fetchFromApi<any[]>("/teams"),
+          fetchFromApi<any[]>("/players"),
         ]);
-        const teams = await teamsRes.json();
-        const players = await playersRes.json();
+        if (!teams || !players) {
+          setTeam(null);
+          setRoster([]);
+          setLoading(false);
+          return;
+        }
 
         // Função para normalizar slugs (caso-insensível, underscore)
         const norm = (str: string) =>

--- a/frontend/src/utils/apiUtils.ts
+++ b/frontend/src/utils/apiUtils.ts
@@ -11,8 +11,11 @@ export const API_URL = (
  * Generic function to fetch data from an API
  */
 export async function fetchFromApi<T>(url: string, options: RequestInit = {}): Promise<T | null> {
+  const fullUrl = url.startsWith('http')
+    ? url
+    : `${API_URL}${url.startsWith('/') ? '' : '/'}${url}`;
   try {
-    const response = await fetch(url, options);
+    const response = await fetch(fullUrl, options);
     
     if (!response.ok) {
       throw new Error(`API error: ${response.status}`);


### PR DESCRIPTION
## Summary
- ensure API helpers prefix URLs with the backend base URL
- use `fetchFromApi` in `TeamDetailPage` for more robust data fetching

## Testing
- `npm run lint` *(fails: no dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6882712639948331b067e0437f1f5986