### PR TITLE
Fix profile page for new users

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -52,12 +52,24 @@ const Navbar = () => {
                   👋 Olá, <strong>{user.username}</strong>
                 </span>
                 <div className="flex items-center space-x-2">
-                  <img src={teamLogos[user.teams.afc]} alt="AFC Team" className="h-6 w-6" />
-                  <span className="text-sm">{user.teams.afc}</span>
+                  <img
+                    src={teamLogos[(user.teams.afc as any).nick || (user.teams.afc as any).split?.(" ").pop() || user.teams.afc]}
+                    alt="AFC Team"
+                    className="h-6 w-6"
+                  />
+                  <span className="text-sm">
+                    {(user.teams.afc as any).name || user.teams.afc}
+                  </span>
                 </div>
                 <div className="flex items-center space-x-2">
-                  <img src={teamLogos[user.teams.nfc]} alt="NFC Team" className="h-6 w-6" />
-                  <span className="text-sm">{user.teams.nfc}</span>
+                  <img
+                    src={teamLogos[(user.teams.nfc as any).nick || (user.teams.nfc as any).split?.(" ").pop() || user.teams.nfc]}
+                    alt="NFC Team"
+                    className="h-6 w-6"
+                  />
+                  <span className="text-sm">
+                    {(user.teams.nfc as any).name || user.teams.nfc}
+                  </span>
                 </div>
               </div>
               <Link to="/profile" className="hover:text-nfl-red px-3 py-2">
@@ -114,12 +126,24 @@ const Navbar = () => {
                   </span>
                 </div>
                 <div className="flex items-center space-x-2 mt-2">
-                  <img src={teamLogos[user.teams.afc]} alt="AFC Team" className="h-6 w-6" />
-                  <span className="text-sm">{user.teams.afc}</span>
+                  <img
+                    src={teamLogos[(user.teams.afc as any).nick || (user.teams.afc as any).split?.(" ").pop() || user.teams.afc]}
+                    alt="AFC Team"
+                    className="h-6 w-6"
+                  />
+                  <span className="text-sm">
+                    {(user.teams.afc as any).name || user.teams.afc}
+                  </span>
                 </div>
                 <div className="flex items-center space-x-2 mt-2">
-                  <img src={teamLogos[user.teams.nfc]} alt="NFC Team" className="h-6 w-6" />
-                  <span className="text-sm">{user.teams.nfc}</span>
+                  <img
+                    src={teamLogos[(user.teams.nfc as any).nick || (user.teams.nfc as any).split?.(" ").pop() || user.teams.nfc]}
+                    alt="NFC Team"
+                    className="h-6 w-6"
+                  />
+                  <span className="text-sm">
+                    {(user.teams.nfc as any).name || user.teams.nfc}
+                  </span>
                 </div>
                 <Link to="/profile" className="hover:text-nfl-red px-3 py-2 mt-2" onClick={() => setMenuOpen(false)}>
                   Profile

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -27,8 +27,11 @@ const ProfilePage = () => {
 
   // Adapte os anos conforme o seu capData e playerData
   const years = [2025, 2026, 2027, 2028, 2029, 2030];
-  const selectedTeam: UserTeam | undefined =
-    user?.teams?.[selectedTeamType.toLowerCase() as "afc" | "nfc"];
+  const rawTeam = user?.teams?.[
+    selectedTeamType.toLowerCase() as "afc" | "nfc"
+  ];
+  const selectedTeam =
+    typeof rawTeam === "string" ? { name: rawTeam } : (rawTeam as UserTeam);
   const teamName = selectedTeam?.name || "";
 
   const fetchData = async () => {
@@ -78,18 +81,20 @@ const ProfilePage = () => {
       <h1 className="text-3xl font-bold">Olá, {user.username}</h1>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {["afc", "nfc"].map((conf) => {
-          const t: UserTeam | undefined = user.teams[conf];
+          const raw = user.teams[conf];
+          const team = typeof raw === "string" ? { name: raw } : (raw as UserTeam);
+          const logoKey = team.nick || team.name?.split(" ").pop() || "";
           return (
             <Card key={conf}>
               <CardHeader>
                 <div className="flex items-center gap-3">
                   <img
-                    src={teamLogos[t?.nick] || GenericLogo}
-                    alt={t?.name}
+                    src={teamLogos[logoKey] || GenericLogo}
+                    alt={team.name}
                     className="w-10 h-10 object-contain"
                   />
                   <CardTitle>
-                    {conf.toUpperCase()}: {t?.name}
+                    {conf.toUpperCase()}: {team.name}
                   </CardTitle>
                 </div>
               </CardHeader>
@@ -120,7 +125,7 @@ const ProfilePage = () => {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <img
-                  src={teamLogos[selectedTeam?.nick] || GenericLogo}
+                  src={teamLogos[selectedTeam?.nick || teamName.split(" ").pop() || ""] || GenericLogo}
                   alt={teamName}
                   className="w-6 h-6 object-contain"
                 />
@@ -163,7 +168,7 @@ const ProfilePage = () => {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <img
-                  src={teamLogos[selectedTeam?.nick] || GenericLogo}
+                  src={teamLogos[selectedTeam?.nick || teamName.split(" ").pop() || ""] || GenericLogo}
                   alt={teamName}
                   className="w-6 h-6 object-contain"
                 />


### PR DESCRIPTION
## Summary
- handle cases where team info is stored as plain strings
- show correct logos and names in Navbar and ProfilePage

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/liga-cap-app/frontend/node_modules/@eslint/js/index.js' imported from /workspace/liga-cap-app/frontend/eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_6883b55a58f48331a68a197179e2c461