### PR TITLE
Fix profile logos

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
-import { teamLogos } from "@/utils/teamLogos";
 import GenericLogo from "@/assets/logos/genericlogo.jpeg";
+import { getTeamLogo } from "@/utils/getTeamLogo";
 
 const Navbar = () => {
   const { user, logout } = useAuth();
@@ -53,7 +53,7 @@ const Navbar = () => {
                 </span>
                 <div className="flex items-center space-x-2">
                   <img
-                    src={teamLogos[(user.teams.afc as any).nick || (user.teams.afc as any).split?.(" ").pop() || user.teams.afc]}
+                    src={getTeamLogo((user.teams.afc as any).id || (user.teams.afc as any).nick || user.teams.afc)}
                     alt="AFC Team"
                     className="h-6 w-6"
                   />
@@ -63,7 +63,7 @@ const Navbar = () => {
                 </div>
                 <div className="flex items-center space-x-2">
                   <img
-                    src={teamLogos[(user.teams.nfc as any).nick || (user.teams.nfc as any).split?.(" ").pop() || user.teams.nfc]}
+                    src={getTeamLogo((user.teams.nfc as any).id || (user.teams.nfc as any).nick || user.teams.nfc)}
                     alt="NFC Team"
                     className="h-6 w-6"
                   />
@@ -127,7 +127,7 @@ const Navbar = () => {
                 </div>
                 <div className="flex items-center space-x-2 mt-2">
                   <img
-                    src={teamLogos[(user.teams.afc as any).nick || (user.teams.afc as any).split?.(" ").pop() || user.teams.afc]}
+                    src={getTeamLogo((user.teams.afc as any).id || (user.teams.afc as any).nick || user.teams.afc)}
                     alt="AFC Team"
                     className="h-6 w-6"
                   />
@@ -137,7 +137,7 @@ const Navbar = () => {
                 </div>
                 <div className="flex items-center space-x-2 mt-2">
                   <img
-                    src={teamLogos[(user.teams.nfc as any).nick || (user.teams.nfc as any).split?.(" ").pop() || user.teams.nfc]}
+                    src={getTeamLogo((user.teams.nfc as any).id || (user.teams.nfc as any).nick || user.teams.nfc)}
                     alt="NFC Team"
                     className="h-6 w-6"
                   />

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -4,8 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { API_URL } from "@/utils/apiUtils";
-import { teamLogos } from "@/utils/teamLogos";
-import GenericLogo from "@/assets/logos/genericlogo.jpeg"; // Uma logo padrão
+import { getTeamLogo } from "@/utils/getTeamLogo";
 import SalaryOverview from "@/components/SalaryOverview";
 
 interface UserTeam {
@@ -102,7 +101,7 @@ const ProfilePage = () => {
               <CardHeader>
                 <div className="flex items-center gap-3">
                   <img
-                    src={teamLogos[logoKey] || GenericLogo}
+                    src={getTeamLogo(team.id || logoKey)}
                     alt={team.name}
                     className="w-10 h-10 object-contain"
                   />
@@ -139,7 +138,7 @@ const ProfilePage = () => {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <img
-                  src={teamLogos[selectedTeam?.nick || teamName.split(" ").pop() || ""] || GenericLogo}
+                  src={getTeamLogo(selectedTeam?.id || selectedTeam?.nick || teamName)}
                   alt={teamName}
                   className="w-6 h-6 object-contain"
                 />
@@ -187,7 +186,7 @@ const ProfilePage = () => {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <img
-                  src={teamLogos[selectedTeam?.nick || teamName.split(" ").pop() || ""] || GenericLogo}
+                  src={getTeamLogo(selectedTeam?.id || selectedTeam?.nick || teamName)}
                   alt={teamName}
                   className="w-6 h-6 object-contain"
                 />

--- a/frontend/src/pages/TeamDetailPage.tsx
+++ b/frontend/src/pages/TeamDetailPage.tsx
@@ -18,17 +18,7 @@ import {
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
 
 import { fetchFromApi } from "@/utils/apiUtils";
-
-
-// Função para importar logo pelo teamId
-const getTeamLogo = (teamId: string) => {
-  try {
-    return new URL(`/src/assets/logos/${teamId}.png`, import.meta.url).href;
-  } catch {
-    /* @vite-ignore */
-    return new URL(`/src/assets/logos/genericlogo.png`, import.meta.url).href;
-  }
-};
+import { getTeamLogo } from "@/utils/getTeamLogo";
 
 const TeamDetailPage = () => {
   const { teamId } = useParams();

--- a/frontend/src/utils/getTeamLogo.ts
+++ b/frontend/src/utils/getTeamLogo.ts
@@ -1,0 +1,16 @@
+export function getTeamLogo(idOrName: string): string {
+  try {
+    const slug = (idOrName || '')
+      .toLowerCase()
+      .trim()
+      .replace(/\s+/g, '_')
+      .replace(/[^a-z0-9_]/g, '');
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore - Vite will handle asset url at build time
+    return new URL(`/src/assets/logos/${slug}.png`, import.meta.url).href;
+  } catch {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore - Vite will handle asset url at build time
+    return new URL('/src/assets/logos/genericlogo.jpeg', import.meta.url).href;
+  }
+}


### PR DESCRIPTION
## Summary
- add `getTeamLogo` utility to load logos from local assets
- replace remote logo lookups in TeamDetailPage, ProfilePage and Navbar with the new utility

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883c5ebf3248331bc665fd33d504cf6