### PR TITLE
Implement alias greeting on profile

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -35,6 +35,7 @@ def login():
     return jsonify({
         "user": {
             "username": username,
+            "alias": user.get("alias", username),
             "teams": user["teams"]
         },
         "token": "fake-jwt-token"

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -18,8 +18,8 @@ export const AuthProvider = ({ children }) => {
     }
   }, []);
 
-  const login = (username, teams) => {
-    const userData = { username, teams };
+  const login = (username, alias, teams) => {
+    const userData = { username, alias, teams };
     setUser(userData);
     localStorage.setItem("user", JSON.stringify(userData));
   };

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -25,7 +25,7 @@ const LoginPage = () => {
       });
       if (!res.ok) throw new Error("Login failed");
       const data = await res.json();
-      login(data.user.username, data.user.teams);
+      login(data.user.username, data.user.alias, data.user.teams);
       navigate("/profile");
     } catch {
       setError("Login inválido. Confira usuário e senha.");

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -90,7 +90,7 @@ const ProfilePage = () => {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-3xl font-bold">Olá, {user.username}</h1>
+      <h1 className="text-3xl font-bold">Olá, {user.alias || user.username}</h1>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {["afc", "nfc"].map((conf) => {
           const raw = user.teams[conf];


### PR DESCRIPTION
## Summary
- send alias from backend login response
- store alias in frontend auth context
- use alias in login and profile greeting

## Testing
- `npm install` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_6883cec53204833194fc765d7e02bbf4