### PR TITLE
Fix navbar alias display

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -49,7 +49,7 @@ const Navbar = () => {
             <>
               <div className="flex items-center space-x-4">
                 <span className="text-sm">
-                  👋 Olá, <strong>{user.username}</strong>
+                  👋 Olá, <strong>{user.alias || user.username}</strong>
                 </span>
                 <div className="flex items-center space-x-2">
                   <img
@@ -122,7 +122,7 @@ const Navbar = () => {
               <>
                 <div className="flex items-center space-x-2 mt-2">
                   <span className="text-sm">
-                    👋 Olá, <strong>{user.username}</strong>
+                    👋 Olá, <strong>{user.alias || user.username}</strong>
                   </span>
                 </div>
                 <div className="flex items-center space-x-2 mt-2">


### PR DESCRIPTION
## Summary
- show `user.alias` in navbar instead of username

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6883e17fb9908331a70a0c72a82046ab