### PR TITLE
Fix dashboard cap tables layout

### DIFF
--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -102,7 +102,7 @@ const Dashboard = () => {
             <CardTitle>Top Teams by Salary Cap Used</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4">
               {["AFC", "NFC"].map((conf) => {
                 const topTeams = [...teamsData]
                   .filter(


### PR DESCRIPTION
## Summary
- stack the conference tables in the dashboard's "Top Teams by Salary Cap Used" section so AFC and NFC are listed vertically

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6883e3182e1c8331bd84beb17aed9ccc